### PR TITLE
Monitoring Improvements: Prometheus client to export receiver up stat…

### DIFF
--- a/src/tests/utils/test_metric_exporter.py
+++ b/src/tests/utils/test_metric_exporter.py
@@ -7,8 +7,8 @@ from qat_rpc.utils.metrics import (
     BinaryMutableOutcome,
     IncrementMutableOutcome,
     MetricExporter,
-    ReceiverBackend,
     ReceiverAdapter,
+    ReceiverBackend,
 )
 
 
@@ -87,7 +87,9 @@ def test_metric_exporter_context_manager_with_sticky_false(mock_backend):
 def test_increment_metric_exporter_single_increment(mock_increment_backend):
     with MetricExporter(backend=mock_increment_backend).failed_messages() as metric:
         metric.increment()
-    expected_increment_outcome = mock_increment_backend.decorated.failed_messages.call_args[0][0]
+    expected_increment_outcome = mock_increment_backend.decorated.failed_messages.call_args[
+        0
+    ][0]
     assert float(expected_increment_outcome) == 1.0
     mock_increment_backend.decorated.failed_messages.assert_called_once_with(
         expected_increment_outcome


### PR DESCRIPTION
This PR addresses key points discussed previously:

Reuse Classes Available for Testing:
Reused the classes available in metrics.py to improve consistency and reduce redundancy in our test suite.

Related Issues
This PR is based on discussions in PR https://github.com/oqc-community/qat-rpc/pull/4 "Monitoring: Prometheus client to export receiver up statuses and other metrics".